### PR TITLE
Introduce history mode

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -55,6 +55,7 @@ Sparky.task("config", () => {
 
     if(!isProduction){
         fuse.dev({
+            fallback: "index.html",
             open: true,
             port: 8080
         });

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ Vue.use(VueRouter);
 Vue.use(Vuetify);
 
 const router = new VueRouter({
+  mode: 'history',
   routes: [
     { path: '/', component: Home },
     { path: '/config', component: Config }


### PR DESCRIPTION
Hello,

I was playing a bit with the Vue project and I noticed that you can introduce a small improvement. I hope I'll be able to help with more Vue related fixes and suggestions in the future, but for now, here is the PR. :)

**Q. What kind of change does this PR introduce?**

A. This introduce history mode for Vue project (the setup that the newest Vue project templates are using these days). To achieve this along with the routes history mode, a fallback file was setup for development.

**Q. Does this PR introduce a breaking change?**

A. Yes. The project will work in history mode from now on.

Instead of accessing a route this way:
http://localhost:8080/#/config

The users will have to access it as following:
http://localhost:8080/config

Best,
Razvan